### PR TITLE
horcrux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ exports.version = '1.0.0'
 exports.manifest = {
   replicate: 'duplex',
   request: 'sync',
+  remoteFeedSequence: 'async'
 }
 exports.permissions = {
   anonymous: {allow: ['replicate']},
@@ -132,7 +133,17 @@ exports.init = function (sbot, config) {
       )
   })
 
+  var remoteSequenceCache = {}
   return {
+    remoteFeedSequence: function (cb) {
+      var peers = ebt.state.peers
+      var feedId = sbot.id
+      Object.keys(peers).forEach(function (peer) {
+        remoteSequenceCache[peer] = peers[peer].clock[feedId]
+      })
+
+      cb(null, remoteSequenceCache)
+    },
     replicate: function (opts) {
       if(opts.version !== 2 && opts.version != 3)
         throw new Error('expected ebt.replicate({version: 3 or 2})')


### PR DESCRIPTION
@dominictarr here's the modification which allows client access to peers seq of you.

Here's the client side code I'm running to get output

```js
var count = 0

  function getMySeq (server) {
    server.ebt.remoteFeedSequence((err, data) => {
      server.latestSequence(server.id, (err, seq) => {
        console.log(`${count} mins`)
        count = count + 1
        console.log('actual seq:', seq)
        console.log(JSON.stringify(data, null, 2))
        console.log('------------------')
      })
    })

    setTimeout(() => getMySeq(server), 60000)
  }
```

For out context the Ticktack pubs are  
```js
        console.log('ticktack pubs', [
          '@7xMrWP8708+LDvaJrRMRQJEixWYp4Oipa9ohqY7+NyQ=.ed25519',
          '@MflVZCcOBOUe6BLrm/8TyirkTu9/JtdnIJALcd8v5bc=.ed25519'
        ])
```