### PR TITLE
Only replicate within hops

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,11 @@ exports.init = function (sbot, config) {
         })
       )
     }
-    if (!withinHops) return
+
+    if (!withinHops)  {
+      sbot.emit('replicate:finish', ebt.state.clock)
+      return
+    }
 
     if(isClient) {
       var opts = {version: 3}

--- a/index.js
+++ b/index.js
@@ -104,13 +104,14 @@ exports.init = function (sbot, config) {
   sbot.on('rpc:connect', function (rpc, isClient) {
     if (rpc.id == sbot.id) return
 
+    var serverHops = config.friends && config.friends.hops || 3
     var withinHops = true
     if(sbot.friends) {
       pull(
         sbot.friends.hopStream(),
         pull.drain(s => {
           var hops = s[rpc.id]
-          if (hops == undefined || hops > config.friends.hops) {
+          if (hops == undefined || hops > serverHops) {
             sbot.emit('log:info', ['SBOT', 'connection outside hops, not ebt replicating: ', hops])
             withinHops = false
           } else


### PR DESCRIPTION
The idea with this pull request is that we shouldn't start replicating with any peers outside our hops. As it is now, sbot can connect to anyone but will only sync feeds within our hops.

The biggest reason for this change is that right now anyone can connect to any peer and start requesting all feeds and thus map the whole network and use this for whatever reason they might have.

I have tested this against scuttlebot with ssb-friends 3.1.3 and all tests are passing. Furthermore as far as I can read, invite does not use this code, so is not affected by this change. 

This still leaves old-style replication, maybe we can disable it by default? And I wonder if this should be a flag or not. 