### PR TITLE
use nyc test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cat-names": "^2.0.0",
     "cont": "^1.0.3",
     "dog-names": "^1.0.2",
+    "nyc": "^13.2.0",
     "rng": "^0.2.2",
     "ssb-client": "^4.5.7",
     "ssb-friends": "^3.1.11",
@@ -29,8 +30,18 @@
     "ssb-validate": "0.0.0"
   },
   "scripts": {
-    "test": "set -e; for t in test/*.js; do echo \"#Test: $t\"; node $t; done"
+    "test": "set -e; for t in test/*.js; do echo \"#Test: $t\"; node $t; done",
+    "coverage": "nyc --reporter=lcov npm test"
   },
   "author": "'Dominic Tarr' <dominic.tarr@gmail.com> (http://dominictarr.com)",
-  "license": "MIT"
+  "license": "MIT",
+  "nyc": {
+    "exclude": [
+      "!**/node_modules/"
+    ],
+    "include": [
+      "node_modules/epidemic-broadcast-trees/*.js",
+      "*.js"
+    ]
+  }
 }


### PR DESCRIPTION
I added a test coverage script. I think it's important not to take coverage too seriously. but it's very interesting to know that something doesn't have coverage.

I had previously tried istanbul, but was blocked because it only worked when all the tests were in one node process.

I also figured out the config so that I can include coverage for key deps - in this case epidemic-broadcast-trees. of course, this has it's own tests, too. so anyway, this shows which ebt features we are actually using.