### PR TITLE
remove dependency on friends, but hook replicate.block

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "nyc": "^13.2.0",
     "rng": "^0.2.2",
     "ssb-client": "^4.5.7",
-    "ssb-friends": "^3.1.11",
+    "ssb-friends": "github:ssbc/ssb-friends#refactor",
     "ssb-generate": "^1.0.1",
     "ssb-gossip": "^1.0.1",
-    "ssb-replicate": "^1.0.1",
+    "ssb-replicate": "github:ssbc/ssb-replicate#refactor",
     "ssb-server": "^13.5.2",
     "ssb-validate": "^4.0.4"
   },


### PR DESCRIPTION
update ssb-ebt so it no longer depends on ssb-friends,
which now calls `replicate.block`
(also, hook replicate.block if necessary)

This is the first step towards implementing @staltz suggestion that ssb-ebt should wrap ssb-replicate.
So, this still expects that ssb-ebt is installed with ssb-replicate, but disentangles the things that are simpler than that.
