### PR TITLE
Report peer timestamps through peerStatus

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,6 +180,7 @@ exports.init = function (sbot, config) {
           var rep = peer.replicating && peer.replicating[id]
           data.peers[k] = {
             seq: peer.clock[id],
+            ts: peer.ts,
             replicating: rep
           }
         }


### PR DESCRIPTION
Pass the peer's last updated timestamp back up the chain through peerStatus so it can be used by the caller to show when the peer was last updated.