### PR TITLE
V6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssb-ebt",
   "description": "scaleable scuttlebutt replication for ssb",
-  "version": "6.0.0-rc1",
+  "version": "6.0.0",
   "homepage": "https://github.com/ssbc/ssb-ebt",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssb-ebt",
   "description": "scaleable scuttlebutt replication for ssb",
-  "version": "5.6.7",
+  "version": "6.0.0-rc1",
   "homepage": "https://github.com/ssbc/ssb-ebt",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "base64-url": "^2.2.0",
-    "epidemic-broadcast-trees": "7",
+    "epidemic-broadcast-trees": "^8.0.1",
     "lossy-store": "^1.2.3",
     "pull-stream": "^3.5.0",
     "push-stream-to-pull-stream": "^1.0.0",
@@ -23,7 +23,9 @@
     "nyc": "^13.2.0",
     "pull-paramap": "^1.2.2",
     "rng": "^0.2.2",
+    "tape": "^5.2.1",
     "secret-stack": "^6.1.2",
+    "ssb-keys": "8.0.2",
     "ssb-client": "^4.7.7",
     "ssb-db": "^19.2.0",
     "ssb-friends": "^4.0.0",


### PR DESCRIPTION
On this branch `v6` I released `6.0.0-rc1` a month ago and it's been working in manyverse in production. This branch should be merged into `master` and we should publish `6.0.0` proper.