### PR TITLE
replace continuables with async-await in tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ exports.init = function (sbot, config) {
   })
 
   function onClose () {
-    // TODO: remove this, no one seems to depend on it
+    // TODO: delete this, it seems to be used only in tests
     sbot.emit('replicate:finish', ebt.state.clock)
   }
 

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "devDependencies": {
     "cat-names": "^3.0.0",
-    "cont": "^1.0.3",
-    "deep-equal": "^1.0.1",
     "dog-names": "^2.0.0",
     "nyc": "^13.2.0",
+    "promisify-4loc": "^1.0.0",
+    "promisify-tuple": "^1.2.0",
     "pull-paramap": "^1.2.2",
     "rng": "^0.2.2",
     "secret-stack": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "dog-names": "^2.0.0",
     "nyc": "^13.2.0",
     "promisify-4loc": "^1.0.0",
-    "promisify-tuple": "^1.2.0",
     "pull-paramap": "^1.2.2",
     "rng": "^0.2.2",
     "secret-stack": "^6.1.2",

--- a/test/block.js
+++ b/test/block.js
@@ -22,7 +22,7 @@ const createSsbServer = SecretStack({
 // 2. alice never tries to connect to bob. (removed from peers)
 // 3. carol will not give bob any, she will not give him any data from alice.
 
-const CONNECTION_TIMEOUT = 500
+const CONNECTION_TIMEOUT = 500 // ms
 const REPLICATION_TIMEOUT = 2 * CONNECTION_TIMEOUT
 
 const alice = createSsbServer({

--- a/test/block.js
+++ b/test/block.js
@@ -111,17 +111,18 @@ tape('alice blocks bob, and bob cannot connect to alice', async (t) => {
   t.end()
 })
 
-tape('carol does not let bob replicate with alice', async (t) => {
+tape('carol does replicate alice\'s data with bob', async (t) => {
   t.plan(1)
   // first, carol should have already replicated with alice.
   // emits this event when did not allow bob to get this data.
-  await Promise.all([
-    pify(bob.connect)(carol.getAddress()),
-    sleep(REPLICATION_TIMEOUT),
-  ])
+  const rpcBobToCarol = await pify(bob.connect)(carol.getAddress())
+  await sleep(REPLICATION_TIMEOUT)
+
+  await pify(rpcBobToCarol.close)(true)
 
   const clock = await pify(bob.getVectorClock)()
   t.equal(clock[alice.id], 1)
+
   t.end()
 })
 

--- a/test/block.js
+++ b/test/block.js
@@ -111,7 +111,7 @@ tape('alice blocks bob, and bob cannot connect to alice', async (t) => {
   t.end()
 })
 
-tape('carol does replicate alice\'s data with bob', async (t) => {
+tape('carol does not replicate alice\'s data with bob', async (t) => {
   t.plan(1)
   // first, carol should have already replicated with alice.
   // emits this event when did not allow bob to get this data.

--- a/test/block2.js
+++ b/test/block2.js
@@ -22,7 +22,6 @@ const alice = createSsbServer({
   timeout: CONNECTION_TIMEOUT,
   keys: ssbKeys.generate(),
   replicate: { legacy: false },
-  gossip: { pub: false }
 })
 
 const bob = createSsbServer({
@@ -30,7 +29,6 @@ const bob = createSsbServer({
   timeout: CONNECTION_TIMEOUT,
   keys: ssbKeys.generate(),
   replicate: { legacy: false },
-  gossip: { pub: false }
 })
 
 tape('alice blocks bob while he is connected, she should disconnect him', async (t) => {

--- a/test/block2.js
+++ b/test/block2.js
@@ -14,7 +14,7 @@ const createSsbServer = SecretStack({
   .use(require('ssb-friends'))
   .use(require('..'))
 
-const CONNECTION_TIMEOUT = 500
+const CONNECTION_TIMEOUT = 500 // ms
 const REPLICATION_TIMEOUT = 2 * CONNECTION_TIMEOUT
 
 const alice = createSsbServer({

--- a/test/block3.js
+++ b/test/block3.js
@@ -22,7 +22,7 @@ const createSsbServer = SecretStack({
   .use(require('ssb-friends'))
   .use(require('..'))
 
-const CONNECTION_TIMEOUT = 500
+const CONNECTION_TIMEOUT = 500 // ms
 const REPLICATION_TIMEOUT = 2 * CONNECTION_TIMEOUT
 
 const alice = createSsbServer({

--- a/test/generate.js
+++ b/test/generate.js
@@ -19,7 +19,7 @@ const createSbot = SecretStack({
 // some of the peers might be too far from the followed peer.
 // TODO: create a thing that checks they where all actually reachable!
 
-const CONNECTION_TIMEOUT = 500
+const CONNECTION_TIMEOUT = 500 // ms
 const REPLICATION_TIMEOUT = 2 * CONNECTION_TIMEOUT
 
 const alice = createSbot({

--- a/test/generate.js
+++ b/test/generate.js
@@ -24,8 +24,6 @@ const REPLICATION_TIMEOUT = 2 * CONNECTION_TIMEOUT
 
 const alice = createSbot({
   temp: 'alice',
-  port: 55451,
-  host: 'localhost',
   timeout: CONNECTION_TIMEOUT,
   replicate: { hops: 3, legacy: false },
   keys: ssbKeys.generate()
@@ -33,8 +31,6 @@ const alice = createSbot({
 
 const bob = createSbot({
   temp: 'bob',
-  port: 55452,
-  host: 'localhost',
   timeout: CONNECTION_TIMEOUT,
   replicate: { hops: 3, legacy: false },
   keys: ssbKeys.generate()

--- a/test/index.js
+++ b/test/index.js
@@ -24,30 +24,22 @@ const REPLICATION_TIMEOUT = 2 * CONNECTION_TIMEOUT
 
 const alice = createSbot({
   temp: 'random-animals_alice',
-  port: 45451,
-  host: 'localhost',
   timeout: CONNECTION_TIMEOUT,
   replicate: { legacy: false },
   keys: ssbKeys.generate(),
-  gossip: { pub: false },
   friends: { hops: 10 }
 })
 
 const bob = createSbot({
   temp: 'random-animals_bob',
-  port: 45452,
-  host: 'localhost',
   timeout: CONNECTION_TIMEOUT,
   replicate: { legacy: false },
   friends: { hops: 10 },
-  gossip: { pub: false },
   keys: ssbKeys.generate()
 })
 
 const charles = createSbot({
   temp: 'random-animals_charles',
-  port: 45453,
-  host: 'localhost',
   timeout: CONNECTION_TIMEOUT,
   replicate: { legacy: false },
   friends: { hops: 10 },

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,7 @@ const createSbot = SecretStack({
   })
   .use(require('../')) // EBT
 
-const CONNECTION_TIMEOUT = 500
+const CONNECTION_TIMEOUT = 500 // ms
 const REPLICATION_TIMEOUT = 2 * CONNECTION_TIMEOUT
 
 const alice = createSbot({
@@ -102,7 +102,7 @@ tape('three peers replicate everything between each other', async (t) => {
 
   const AMOUNT = 10;
   for (let i = 0; i < AMOUNT; i++) {
-    const j = ~~(Math.random() * bots.length)
+    const j = u.randint(bots.length)
     u.log('publish a new post by ' + names[bots[j].id])
     await pify(bots[j].publish)({ type: 'post', text: '' + i })
   }
@@ -124,5 +124,4 @@ tape('three peers replicate everything between each other', async (t) => {
     pify(charles.close)(true),
   ]);
   t.end()
-  return
 })

--- a/test/legacy.js
+++ b/test/legacy.js
@@ -18,7 +18,7 @@ const createSbot = SecretStack({
   })
   .use(require('../')) // EBT
 
-const CONNECTION_TIMEOUT = 500
+const CONNECTION_TIMEOUT = 500 // ms
 
 const bobKeys = ssbKeys.generate()
 

--- a/test/legacy.js
+++ b/test/legacy.js
@@ -18,13 +18,13 @@ const createSbot = SecretStack({
   })
   .use(require('../')) // EBT
 
+const CONNECTION_TIMEOUT = 500
+
 const bobKeys = ssbKeys.generate()
 
 const alice = createSbot({
   temp: 'random-animals',
-  port: 45451,
-  host: 'localhost',
-  timeout: 20001,
+  timeout: CONNECTION_TIMEOUT,
   replicate: { hops: 3, legacy: false },
   keys: ssbKeys.generate()
 })

--- a/test/misc/util.js
+++ b/test/misc/util.js
@@ -72,14 +72,14 @@ exports.countClock = function (obj) {
   return { total, sum }
 }
 
-exports.randint = function (n) {
-  return ~~(Math.random() * n)
+exports.randint = function (max) {
+  return ~~(Math.random() * max)
 }
 
-exports.randary = function (a) {
-  return a[exports.randint(a.length)]
+exports.randary = function (ary) {
+  return ary[exports.randint(ary.length)]
 }
 
-exports.randbytes = function (n) {
-  return crypto.randomBytes(n)
+exports.randbytes = function (size) {
+  return crypto.randomBytes(size)
 }

--- a/test/misc/util.js
+++ b/test/misc/util.js
@@ -1,3 +1,5 @@
+const crypto = require('crypto')
+const ssbKeys = require('ssb-keys')
 const ref = require('ssb-ref')
 
 exports.follow = function (id) {
@@ -32,4 +34,52 @@ exports.file = function (hash) {
     type: 'file',
     file: hash
   }
+}
+
+exports.keysFor = function (name) {
+  const seed = crypto.createHash('sha256').update(name).digest()
+  return ssbKeys.generate(null, seed)
+}
+
+exports.readOnceFromDB = function (sbot) {
+  return new Promise((resolve) => {
+    var cancel = sbot.post((msg) => {
+      cancel()
+      resolve(msg)
+    }, false)
+  })
+}
+
+exports.trackProgress = function (sbot, name) {
+  let n = 0
+  let n0 = 0
+  sbot.post((msg) => n++)
+  setInterval(() => {
+    if (n0 !== n) {
+      exports.log(name, n, n - n0, sbot.progress())
+      n0 = n
+    }
+  }, 1000).unref()
+}
+
+exports.countClock = function (obj) {
+  let total = 0
+  let sum = 0
+  for (const key in obj) {
+    total++
+    sum += obj[key]
+  }
+  return { total, sum }
+}
+
+exports.randint = function (n) {
+  return ~~(Math.random() * n)
+}
+
+exports.randary = function (a) {
+  return a[exports.randint(a.length)]
+}
+
+exports.randbytes = function (n) {
+  return crypto.randomBytes(n)
 }

--- a/test/random.js
+++ b/test/random.js
@@ -84,12 +84,9 @@ function generateAnimals (bot, mainFeed, amountFeeds, amountMsgs, doneCB) {
 
 const alice = createSsbServer({
   temp: 'ebt_test-random-animals',
-  port: 45651,
-  host: 'localhost',
   timeout: CONNECTION_TIMEOUT,
   replicate: { hops: 3, legacy: false },
   keys: ssbKeys.generate(),
-  gossip: { pub: false }
 })
 
 let liveMsgCount = 0
@@ -164,13 +161,8 @@ tape('replicate social network for animals', async (t) => {
   const start = Date.now()
   const bob = createSsbServer({
     temp: 'ebt_test-random-animals2',
-    port: 45652,
-    host: 'localhost',
     timeout: CONNECTION_TIMEOUT,
     replicate: { hops: 3, legacy: false },
-    gossip: { pub: false },
-    progress: true,
-    seeds: [alice.getAddress()],
     keys: ssbKeys.generate()
   })
 

--- a/test/random.js
+++ b/test/random.js
@@ -22,7 +22,7 @@ const createSsbServer = SecretStack({
 const AMOUNT_FEEDS = 100
 const AMOUNT_MSGS = 10000
 
-const CONNECTION_TIMEOUT = 500
+const CONNECTION_TIMEOUT = 500 // ms
 const REPLICATION_TIMEOUT = 2 * CONNECTION_TIMEOUT
 
 function generateAnimals (bot, mainFeed, amountFeeds, amountMsgs, doneCB) {
@@ -49,7 +49,7 @@ function generateAnimals (bot, mainFeed, amountFeeds, amountMsgs, doneCB) {
       pull(
         pull.count(amountMsgs),
         paramap((i, cb) => {
-          const feed = feeds[~~(Math.random() * feeds.length)]
+          const feed = u.randary(feeds)
           const r = Math.random()
           // log only 1 in 10, less noise
           if (r < 0.1) u.log(i, feed.id, r)
@@ -68,7 +68,7 @@ function generateAnimals (bot, mainFeed, amountFeeds, amountMsgs, doneCB) {
               cb(null, msg)
             })
           } else {
-            const post = posts[~~(Math.random() * posts.length)]
+            const post = u.randary(posts)
             feed.add({
               type: 'post',
               repliesTo: post,

--- a/test/random.js
+++ b/test/random.js
@@ -53,9 +53,9 @@ function generateAnimals (bot, mainFeed, amountFeeds, amountMsgs, doneCB) {
           const r = Math.random()
           // log only 1 in 10, less noise
           if (r < 0.1) u.log(i, feed.id, r)
-          // one in 20 messages is a random follow
+          // 50% of messages are a random follow
           if (r < 0.5) {
-            const otherFeed = feeds[~~(Math.random() * feeds.length)]
+            const otherFeed = u.randary(feeds)
             feed.add(u.follow(otherFeed.id), cb)
           } else if (r < 0.6) {
             feed.add({

--- a/test/realtime.js
+++ b/test/realtime.js
@@ -22,16 +22,21 @@ function createHistoryStream (sbot, opts) {
   )
 }
 
+const CONNECTION_TIMEOUT = 500
+const REPLICATION_TIMEOUT = 2 * CONNECTION_TIMEOUT
+
 tape('replicate between 2 peers', async (t) => {
   t.plan(2)
   const alice = createSsbServer({
     temp: 'test-alice',
+    timeout: CONNECTION_TIMEOUT,
     replicate: { legacy: false },
     keys: ssbKeys.generate()
   })
 
   const bob = createSsbServer({
     temp: 'test-bob',
+    timeout: CONNECTION_TIMEOUT,
     replicate: { legacy: false },
     keys: ssbKeys.generate()
   })
@@ -60,6 +65,8 @@ tape('replicate between 2 peers', async (t) => {
     u.log('added', msg.key, msg.value.sequence)
     await sleep(200)
   }
+
+  await sleep(REPLICATION_TIMEOUT)
 
   const coldMsgs = await new Promise((resolve, reject) => {
     pull(

--- a/test/realtime.js
+++ b/test/realtime.js
@@ -22,7 +22,7 @@ function createHistoryStream (sbot, opts) {
   )
 }
 
-const CONNECTION_TIMEOUT = 500
+const CONNECTION_TIMEOUT = 500 // ms
 const REPLICATION_TIMEOUT = 2 * CONNECTION_TIMEOUT
 
 tape('replicate between 2 peers', async (t) => {

--- a/test/resync.js
+++ b/test/resync.js
@@ -14,7 +14,7 @@ const createSbot = require('secret-stack')({
   .use(require('../'))
   .use(require('ssb-friends'))
 
-const CONNECTION_TIMEOUT = 500
+const CONNECTION_TIMEOUT = 500 // ms
 const REPLICATION_TIMEOUT = 2 * CONNECTION_TIMEOUT
 
 const alice = createSbot({

--- a/test/server.js
+++ b/test/server.js
@@ -18,7 +18,7 @@ const createSsbServer = SecretStack({
   .use(require('..'))
   .use(require('ssb-friends'))
 
-const CONNECTION_TIMEOUT = 500
+const CONNECTION_TIMEOUT = 500 // ms
 const REPLICATION_TIMEOUT = 2 * CONNECTION_TIMEOUT
 
 tape('replicate between 3 peers', async (t) => {


### PR DESCRIPTION
The new async-await control flow makes tests easier to read, since they are sequential (but still allow parallelism via `Promise.all`), a developer reading code doesn't have to jump their eyes up and down trying to follow the flow, and there's no callback pyramid.

In some cases I rewrote the tests, because they either didn't assert anything, or were using inconsistent patterns (it seems like some test files used one way of connecting, while other files used another method, seems to be that one method was an old style).

A big PR, but I feel confident about these tests are now readable and deterministic (don't rely on console.logs to do "human assertion").