### PR TITLE
Fix undefined peer.replicating in peerStatus

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,7 +185,8 @@ exports.init = function (sbot, config) {
     }
     for (const k in ebt.state.peers) {
       const peer = ebt.state.peers[k]
-      if (peer.clock[id] != null || peer.replicating[id] != null) {
+      if (peer.clock[id] != null ||
+          (peer.replicating && peer.replicating[id] != null)) {
         const rep = peer.replicating && peer.replicating[id]
         data.peers[k] = {
           seq: peer.clock[id],


### PR DESCRIPTION
I'm testing unbermuda and ran into this problem in "production". Sorry I don't have a test case for this, but based on the line below it seems to be something someone already has experienced. This problem was also present in 6.0 I see.