### PR TITLE
avoid calling ebt.replicate duplex on ssb-client

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ exports.init = function (sbot, config) {
   }
 
   sbot.on('rpc:connect', function (rpc, isClient) {
-    if (rpc.id === ssb.id) return // ssb-client connecting to ssb-server
+    if (rpc.id === sbot.id) return // ssb-client connecting to ssb-server
     if (isClient) {
       const opts = { version: 3 }
       const local = toPull.duplex(ebt.createStream(rpc.id, opts.version, true))

--- a/index.js
+++ b/index.js
@@ -94,7 +94,8 @@ exports.init = function (sbot, config) {
   }
 
   sbot.on('rpc:connect', function (rpc, isClient) {
-    if (isClient && rpc.id !== sbot.id) {
+    if (rpc.id === ssb.id) return // ssb-client connecting to ssb-server
+    if (isClient) {
       const opts = { version: 3 }
       const local = toPull.duplex(ebt.createStream(rpc.id, opts.version, true))
       const remote = rpc.ebt.replicate(opts, (networkError) => {


### PR DESCRIPTION
Context: using ssb-ebt in Manyverse, which has a muxrpc client on one JS thread calling the sbot muxrpc APIs on another JS thread.

Problem: we should not initiate a `rpc.ebt.replicate` duplex stream with the ssb-client which shares the same SSB ID, and it makes no sense to replicate like that. Also, it caused an error:

```
EBT:dcon @MYSSBID=.ed25519
Error: reconnected to peer
at Object.createStream (/data/data/se.manyver/files/nodejs-project/index.js:60740:37)
at Object.replicate (/data/data/se.manyver/files/nodejs-project/index.js:40975:30)
at Object.hooked (/data/data/se.manyver/files/nodejs-project/index.js:52708:15)
at Object.localCall (/data/data/se.manyver/files/nodejs-project/index.js:60849:29)
at Object.localCallWithPerms (/data/data/se.manyver/files/nodejs-project/index.js:60855:22)
at PacketStreamSubstream.read (/data/data/se.manyver/files/nodejs-project/index.js:1655:19)
at PacketStream._onstream (/data/data/se.manyver/files/nodejs-project/index.js:1982:11)
at PacketStream.write (/data/data/se.manyver/files/nodejs-project/index.js:1886:41)
at /data/data/se.manyver/files/nodejs-project/index.js:25323:15
at /data/data/se.manyver/files/nodejs-project/index.js:26707:37
```

---

**Extras:** some console.log hygiene that makes it easier to know why the error logged is being logged, and from where.