### PR TITLE
Replace obz with p-defer

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "base64-url": "^2.2.0",
     "epidemic-broadcast-trees": "^8.0.4",
     "lossy-store": "^1.2.3",
-    "obz": "^1.0.3",
+    "p-defer": "^3.0.0",
     "pull-defer": "^0.2.3",
     "pull-stream": "^3.6.0",
     "push-stream-to-pull-stream": "^1.0.4",


### PR DESCRIPTION
When trying to write a test that uses ssb-db2 I ran into a race condition where the ebt state clock was set after a publish (sbot.post) call was handled, meaning we would end up with an incorrect state because the vector clock overwrites the current state. Furthermore that was a problem in `request` and `block` where they are using the clock to figure out what to do, but the clock might not have been properly loaded at the time of the request or block call. This PR fixes those 3 cases. 

Lastly this PR changes our synchonization mechanism to be p-defer so promise bases instead of obz. We don't really need all that functionality, the only thing we are interested in is that the clock has been set before we start doing things that needs the state.