### PR TITLE
Change p-defer to a simple waiting queue system

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "base64-url": "^2.2.0",
     "epidemic-broadcast-trees": "^8.0.4",
     "lossy-store": "^1.2.3",
-    "p-defer": "^3.0.0",
     "promisify-4loc": "^1.0.0",
     "pull-defer": "^0.2.3",
     "pull-stream": "^3.6.0",


### PR DESCRIPTION
A bit of background. In https://github.com/ssbc/ssb-ebt/pull/53 we replaced obz with p-defer (a Promise) and added the initialized check to the block function. This change actually broke the `test/integration/block3.js` test inside https://github.com/ssb-ngi-pointer/ssb-replication-scheduler because it was expecting that if you blocked someone that EBT would get that info right away, instead because of the promise it will get it a bit later leading to the blocked message being sent over the network. A promise `then` will add the cb as a microtask to a queue and only run only on next tick. For more information see [this](https://blog.insiderattack.net/new-changes-to-timers-and-microtasks-from-node-v11-0-0-and-above-68d112743eb3) post. After reading that I'm quite skeptical about promises for anything performance critical. The problem is that the all the tasking and waiting is really bad for performance, not to mention can easily lead to subtile concurrency bugs like the one in block.

Now why this PR against an open branch instead of against master that has the bug. Because we are close to landing this partial-replication-changes branch and I didn't want to mess with the potential merge conflicts.

I also think it would be a good idea to move the block3 test from replication scheduler to this repo instead.