### PR TITLE
new forget() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ otherwise the first where isFeed is `true` for `origin` is used.
 
 Returns undefined, always.
 
+### `ssb.ebt.forget(destination)` ("sync" muxrpc API)
+
+Same as `ssb.ebt.request(destination, false)`, but also cleans up any persistent
+state used by the EBT instance for this given `destination` ID.
+
+Returns undefined, always.
+
 ### `ssb.ebt.peerStatus(id)` ("sync" muxrpc API)
 
 Query the status of replication for a given SSB feed ID `id`. Returns a JSON

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ exports.manifest = {
   replicateFormat: 'duplex',
   request: 'sync',
   block: 'sync',
+  forget: 'sync',
   peerStatus: 'sync',
   clock: 'async',
 }
@@ -103,6 +104,7 @@ exports.init = function (sbot, config) {
     ebt.isFeed = isFeed
     ebt.name = format.name
     ebt.prepareForIsFeed = format.prepareForIsFeed.bind(format, sbot)
+    ebt.clearClock = store.delete.bind(store)
 
     const existingId = ebts.findIndex((e) => e.name === format.name)
     if (existingId !== -1) ebts[existingId] = ebt
@@ -239,6 +241,15 @@ exports.init = function (sbot, config) {
     })
   }
 
+  function forget(destFeedId) {
+    onReady(() => {
+      for (const ebt of ebts) {
+        ebt.request(destFeedId, false)
+        ebt.clearClock(destFeedId)
+      }
+    })
+  }
+
   function block(origFeedId, destFeedId, blocking, formatName) {
     onReady(() => {
       const ebt = findEBTForFeed(origFeedId, formatName)
@@ -329,6 +340,7 @@ exports.init = function (sbot, config) {
   return {
     request,
     block,
+    forget,
     replicate: replicateFormat,
     replicateFormat,
     peerStatus,

--- a/index.js
+++ b/index.js
@@ -246,7 +246,7 @@ exports.init = function (sbot, config) {
       for (const ebt of ebts) {
         ebt.request(destFeedId, false)
         ebt.clearClock(destFeedId)
-        delete ebt.state.clock[destFeedId] // TODO: perhaps E-B-T should do this
+        delete ebt.state.clock[destFeedId]
       }
     })
   }

--- a/index.js
+++ b/index.js
@@ -246,6 +246,7 @@ exports.init = function (sbot, config) {
       for (const ebt of ebts) {
         ebt.request(destFeedId, false)
         ebt.clearClock(destFeedId)
+        delete ebt.state.clock[destFeedId] // TODO: perhaps E-B-T should do this
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "base64-url": "^2.2.0",
     "epidemic-broadcast-trees": "^9.0.2",
-    "key-value-file-store": "^1.0.1",
+    "key-value-file-store": "^1.1.1",
     "promisify-4loc": "^1.0.0",
     "pull-defer": "^0.2.3",
     "pull-stream": "^3.6.0",

--- a/test/forget.js
+++ b/test/forget.js
@@ -1,0 +1,92 @@
+const tape = require('tape')
+const crypto = require('crypto')
+const SecretStack = require('secret-stack')
+const sleep = require('util').promisify(setTimeout)
+const pify = require('promisify-4loc')
+const u = require('./misc/util')
+
+const createSsbServer = SecretStack({
+  caps: { shs: crypto.randomBytes(32).toString('base64') },
+})
+  .use(require('ssb-db'))
+  .use(require('../'))
+
+const CONNECTION_TIMEOUT = 500 // ms
+const REPLICATION_TIMEOUT = 2 * CONNECTION_TIMEOUT
+
+const alice = createSsbServer({
+  temp: 'test-delete-alice',
+  timeout: CONNECTION_TIMEOUT,
+  keys: u.keysFor('alice'),
+})
+
+const bob = createSsbServer({
+  temp: 'test-delete-bob',
+  timeout: CONNECTION_TIMEOUT,
+  keys: u.keysFor('bob'),
+})
+
+const carla = createSsbServer({
+  temp: 'test-delete-carla',
+  timeout: CONNECTION_TIMEOUT,
+  keys: u.keysFor('carla'),
+})
+
+tape('after forgetting a feed, replicate stream gives nothing', async (t) => {
+  await Promise.all([
+    pify(alice.publish)({ type: 'post', text: 'hello' }),
+    pify(bob.publish)({ type: 'post', text: 'hello' }),
+    pify(carla.publish)({ type: 'post', text: 'hello' }),
+  ])
+
+  // Self replicate
+  alice.ebt.request(alice.id, true)
+  bob.ebt.request(bob.id, true)
+  carla.ebt.request(carla.id, true)
+
+  // Alice <==> Bob
+  alice.ebt.request(bob.id, true)
+  bob.ebt.request(alice.id, true)
+
+  // Carla <== Alice
+  carla.ebt.request(alice.id, true)
+
+  const clockCarla1 = await pify(carla.ebt.clock)()
+  t.deepEquals(clockCarla1, { [carla.id]: 1 }, 'carla clock ok')
+
+  const rpcBobToAlice = await pify(bob.connect)(alice.getAddress())
+
+  await sleep(REPLICATION_TIMEOUT)
+  t.pass('wait for replication to complete')
+
+  const clockAliceAfter = await pify(alice.ebt.clock)()
+  t.deepEquals(
+    clockAliceAfter,
+    { [alice.id]: 1, [bob.id]: 1 },
+    'alice clock ok'
+  )
+
+  const clockBobAfter = await pify(bob.ebt.clock)()
+  t.deepEquals(clockBobAfter, { [alice.id]: 1, [bob.id]: 1 }, 'bob clock ok')
+
+  await pify(rpcBobToAlice.close)(true)
+
+  bob.ebt.forget(alice.id)
+  t.pass('bob forgets alice')
+
+  const rpcBobToCarla = await pify(bob.connect)(carla.getAddress())
+
+  await sleep(REPLICATION_TIMEOUT)
+  t.pass('wait for replication to complete')
+
+  const clockCarla2 = await pify(carla.ebt.clock)()
+  t.deepEquals(clockCarla2, { [carla.id]: 1 }, 'carla clock ok')
+
+  await pify(rpcBobToCarla.close)(true)
+  await Promise.all([
+    pify(alice.close)(true),
+    pify(bob.close)(true),
+    pify(carla.close)(true),
+  ])
+  t.end()
+})

--- a/test/forget.js
+++ b/test/forget.js
@@ -8,7 +8,8 @@ const u = require('./misc/util')
 const createSsbServer = SecretStack({
   caps: { shs: crypto.randomBytes(32).toString('base64') },
 })
-  .use(require('ssb-db'))
+  .use(require('ssb-db2'))
+  .use(require('ssb-db2/compat/ebt'))
   .use(require('../'))
 
 const CONNECTION_TIMEOUT = 500 // ms
@@ -34,9 +35,9 @@ const carla = createSsbServer({
 
 tape('after forgetting a feed, replicate stream gives nothing', async (t) => {
   await Promise.all([
-    pify(alice.publish)({ type: 'post', text: 'hello' }),
-    pify(bob.publish)({ type: 'post', text: 'hello' }),
-    pify(carla.publish)({ type: 'post', text: 'hello' }),
+    pify(alice.db.publish)({ type: 'post', text: 'hello' }),
+    pify(bob.db.publish)({ type: 'post', text: 'hello' }),
+    pify(carla.db.publish)({ type: 'post', text: 'hello' }),
   ])
 
   // Self replicate
@@ -73,6 +74,9 @@ tape('after forgetting a feed, replicate stream gives nothing', async (t) => {
 
   bob.ebt.forget(alice.id)
   t.pass('bob forgets alice')
+
+  await pify(bob.db.deleteFeed)(alice.id)
+  t.pass("bob deletes alice's messages")
 
   await sleep(REPLICATION_TIMEOUT)
 


### PR DESCRIPTION
**Context:** defrag and compact, see https://github.com/ssb-ngi-pointer/ssb-db2/pull/339

**Problem:** if there is a feedId that we know we will never connect with again, we need a way to clean up the space it uses in disk for persistent EBT state. `request()` with `false` works for the runtime behavior, but it doesn't clean the state in disk. The state in disk can be significant, e.g. my Manyverse Desktop has a 96 MB large `ebt` folder.

**Solution:** new `forget()` API which just does `request(false)` but also deletes the state file.