### PR TITLE
update ssb-uri2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ssb-network-errors": "^1.0.1",
     "ssb-ref": "^2.13.0",
     "ssb-subset-ql": "^0.6.4",
-    "ssb-uri2": "^1.7.2"
+    "ssb-uri2": "^2.0.0"
   },
   "devDependencies": {
     "cat-names": "^3.0.0",
@@ -50,7 +50,7 @@
     "ssb-db2": "^4.0.4",
     "ssb-generate": "^1.0.1",
     "ssb-index-feed-writer": "^0.7.0",
-    "ssb-keys": "^8.2.1",
+    "ssb-keys": "^8.4.0",
     "ssb-meta-feeds": "^0.28.2",
     "ssb-validate": "^4.1.4",
     "tap-spec": "^5.0.0",

--- a/test/formats.js
+++ b/test/formats.js
@@ -8,7 +8,6 @@ const caps = require('ssb-caps')
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')
 const ssbKeys = require('ssb-keys')
-const SSBURI = require('ssb-uri2')
 const bendyButt = require('ssb-bendy-butt')
 const { where, author, type, toPromise } = require('ssb-db2/operators')
 
@@ -47,11 +46,7 @@ let bob = createSSBServer().call(null, {
 
 function getBBMsg(mainKeys) {
   // fake some keys
-  const mfKeys = ssbKeys.generate()
-  const classicUri = SSBURI.fromFeedSigil(mfKeys.id)
-  const { type, /* format, */ data } = SSBURI.decompose(classicUri)
-  const bendybuttUri = SSBURI.compose({ type, format: 'bendybutt-v1', data })
-  mfKeys.id = bendybuttUri
+  const mfKeys = ssbKeys.generate(null, null, 'bendybutt-v1')
 
   const content = {
     type: 'metafeed/add/existing',


### PR DESCRIPTION
Update to `ssb-uri2@2.0.0` (breaking change). Fairly simple changes, no breaking change caused in/from ssb-ebt.